### PR TITLE
Correção CRC16

### DIFF
--- a/pix/pix.go
+++ b/pix/pix.go
@@ -202,7 +202,7 @@ func calculateCRC16(str string) (string, error) {
 		return "", err
 	}
 
-	return strings.ToUpper(fmt.Sprintf("%x", h.Sum16())), nil
+	return fmt.Sprintf("%04X", h.Sum16()), nil
 }
 
 func leadingZeroIfLenSmallerThan10(str string) string {

--- a/pix/pix_test.go
+++ b/pix/pix_test.go
@@ -70,7 +70,7 @@ func TestValues_TransactionID(t *testing.T) {
 			Amount:        20.67,
 			Description:   "Invoice #4",
 			TransactionID: "99999",
-		}, "00020126580014BR.GOV.BCB.PIX0122jonnasfonini@gmail.com0210Invoice #4520400005303986540520.675802BR5913Jonnas Fonini6005Marau624305059999950300017BR.GOV.BCB.BRCODE01051.0.063041F3"},
+		}, "00020126580014BR.GOV.BCB.PIX0122jonnasfonini@gmail.com0210Invoice #4520400005303986540520.675802BR5913Jonnas Fonini6005Marau624305059999950300017BR.GOV.BCB.BRCODE01051.0.0630401F3"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Olá, notei que estava faltando adicionar zeros à esquerda no caso do CRC16 calculado não possuir exatamente 4 caracteres.

Inclusive um dos testes apresentava esse exato problema:

```63.04.1F3```

Como você pode ver, indicava que tinha 4 caracteres, porém só tinha 3.

Segue PR para corrigir esse problema ;)

Não sei se você conhece, mas esse site é interessante:
https://pix.nascent.com.br/tools/pix-qr-decoder/

Vai te ajudar bastante no desenvolvimento ai.

[]'s

